### PR TITLE
Refactor stack navigators into dedicated modules

### DIFF
--- a/components/Home-Page.js
+++ b/components/Home-Page.js
@@ -4,38 +4,16 @@ import {
   ScrollView,
   Text,
   View,
-  Button,
   StyleSheet,
   TouchableOpacity
 } from "react-native";
 import "react-native-gesture-handler";
-import { createStackNavigator } from "@react-navigation/stack";
-import ListingScreen from "./Listing-Screen";
 import GameDay from "../assets/images/gameday.jpeg";
-import { ListingsContext, ListingsProvider } from "../contexts/listingContext";
+import { ListingsContext } from "../contexts/listingContext";
 import { AuthContext } from "../contexts/authContext";
 import { Image as ExpoImage } from 'expo-image';
-import * as Sentry from '@sentry/react-native';
 
-const Stack = createStackNavigator();
-
-export default function Home() {
-  return (
-      <Stack.Navigator>
-        <Stack.Screen
-          name="HomeMain"
-          component={HomeMain}
-          options={{ headerShown: false, headerTitle: "Back" }}
-        />
-        <Stack.Screen
-          name="ListingScreen"
-          component={ListingScreen}
-          options={{ headerTitle: "", headerTintColor: "black" }}
-        />
-      </Stack.Navigator>
-  );
-}
-const HomeMain = ({ navigation }) => {
+export const HomeMain = ({ navigation }) => {
   const { trendingListings, recentListings } = useContext(ListingsContext);
   const { user } = useContext(AuthContext);
 
@@ -151,3 +129,5 @@ const styles = StyleSheet.create({
     marginVertical: 15
   }
 });
+
+export default HomeMain;

--- a/components/Profile-Page.js
+++ b/components/Profile-Page.js
@@ -10,73 +10,18 @@ import {
     Modal,
 } from 'react-native';
 import { useContext, useState, useEffect } from 'react';
-import { useNavigation } from '@react-navigation/native';
 import "react-native-gesture-handler";
 import { Ionicons } from '@expo/vector-icons';
 import { signOut } from "firebase/auth";
-import auth from '../firebase/auth'; 
-import { createStackNavigator } from '@react-navigation/stack';
+import auth from '../firebase/auth';
 import '../firebase/firebase-config';
-import CreateListing from './Create-Listing-Screen';
-import EditProfile from './Edit-Profile-Screen';
-import Offers from './Offers-Screen';
-import Archived from './Archived-Offers-Screen';
 import { AuthContext } from '../contexts/authContext';
-import { ListingsContext, ListingsProvider } from '../contexts/listingContext';
+import { ListingsContext } from '../contexts/listingContext';
 import SwiperFlatList from 'react-native-swiper-flatlist';
-import Login from './Login-Screen';
-import ListingContainer from './Listing-Screen';
-import Checkout from './Checkout-Screen'
 import { Image as ExpoImage } from 'expo-image';
 import stripeService from '../util/stripeService';
 
-export default function Profile() {
-    const Stack = createStackNavigator();
-  
-    return (
-        <Stack.Navigator>
-          <Stack.Screen
-            name="ProfileMain"
-            component={ProfileMain}
-            options={{ headerShown: false, headerTitle: "Back" }}
-          />
-          <Stack.Screen
-              name="ListingScreen"
-              component={ListingContainer}
-              options={{ headerShown: true, headerTitle: "", headerTintColor: '#0e165c' }}
-          />
-          <Stack.Screen
-            name="CreateListing"
-            component={CreateListing}
-            options={{ headerShown: true, headerTitle: "", headerTintColor: '#0e165c' }}
-          />
-          <Stack.Screen
-            name="EditProfile"
-            component={EditProfile}
-            options={{ headerShown: true, headerTitle: "", headerTintColor: '#0e165c' }}
-          />
-          <Stack.Screen
-            name="Offers"
-            component={Offers}
-            options={{ headerShown: true, headerTitle: "", headerTintColor: '#0e165c' }}
-          />
-          <Stack.Screen
-            name="CheckoutScreen"
-            component={Checkout}
-            options={{ headerShown: true, headerTitle: "", headerTintColor: '#0e165c' }}
-          />
-          <Stack.Screen
-            name="Archived"
-            component={Archived}
-            options={{ headerShown: true, headerTitle: "", headerTintColor: '#0e165c' }}
-          />
-         
-        </Stack.Navigator>
-    );
-  }
-  
-  const ProfileMain = () => {
-    const navigation = useNavigation();
+export const ProfileMain = ({ navigation }) => {
     const { userData, likedListingsData } = useContext(AuthContext);
     const { userListings } = useContext(ListingsContext);
     const [helpModalVisible, setHelpModalVisible] = useState(false);
@@ -89,7 +34,7 @@ export default function Profile() {
 
     const handleSignOut = () => {
       signOut(auth).then(() => {
-        navigation.navigate(Login);
+        navigation.navigate('Login');
         Alert.alert("Sign out successful.");
       }).catch((error) => {
         Alert.alert("Error", "Sign out unsuccessful.");
@@ -112,7 +57,7 @@ export default function Profile() {
           ]
         )
         navigation.navigate('ProfileMain');
-      } 
+      }
     }
   
     return (
@@ -207,7 +152,7 @@ export default function Profile() {
         <View style={styles.buttonContainer}>
           <TouchableOpacity
             style={styles.button}
-            onPress={() => navigation.navigate(EditProfile)}
+            onPress={() => navigation.navigate('EditProfile')}
           >
             <Text style={{fontFamily: 'optima'}}>Edit Profile</Text>
           </TouchableOpacity>
@@ -460,3 +405,5 @@ const faqs =[
              "If you would like to submit a report, email to unccampuscloset@gmail.com"
   }
 ];
+
+export default ProfileMain;

--- a/components/Shop-Page.js
+++ b/components/Shop-Page.js
@@ -16,33 +16,11 @@ import {
 import "react-native-gesture-handler";
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { FontAwesome } from "@expo/vector-icons";
-import { createStackNavigator } from "@react-navigation/stack";
-import ListingScreen from "./Listing-Screen";
 import { ListingsContext } from "../contexts/listingContext";
 import sizes from "../util/sizes";
 import { Image as ExpoImage } from 'expo-image';
 
-
-export default function ShopContent() {
-  const Stack = createStackNavigator();
-
-  return (
-    <Stack.Navigator>
-      <Stack.Screen
-        name="ShopMain"
-        component={ShopMain}
-        options={{ headerShown: false, headerTitle: "Back" }}
-      />
-      <Stack.Screen
-        name="ListingScreen"
-        component={ListingScreen}
-        options={{ headerTitle: "", headerTintColor: "black" }}
-      />
-    </Stack.Navigator>
-  );
-}
-
-const ShopMain = ({ navigation }) => {
+export const ShopMain = ({ navigation }) => {
   const [searchQuery, setSearchQuery] = useState("");
 
   const [sizeModalVisible, setSizeModalVisible] = useState(false);
@@ -56,10 +34,9 @@ const ShopMain = ({ navigation }) => {
   const [minPrice, setMinPrice] = useState(null);
   const [maxPrice, setMaxPrice] = useState(null);
 
+  const { listings, fetchMoreListings, loadingMore } = useContext(ListingsContext);
   const [filteredListings, setFilteredListings] = useState(listings);
   const [filtersActive, setFiltersActive] = useState(false);
-
-  const { listings, fetchMoreListings, loadingMore } = useContext(ListingsContext);
 
   // get filtered listings based on user selection
   useEffect(() => {
@@ -546,3 +523,5 @@ const styles = StyleSheet.create({
     fontFamily: 'optima',
   }
 });
+
+export default ShopMain;

--- a/components/Tab-Bar.js
+++ b/components/Tab-Bar.js
@@ -1,13 +1,12 @@
 import React from "react";
 import { StyleSheet } from 'react-native';
-import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { AntDesign } from '@expo/vector-icons';
 import { MaterialIcons } from '@expo/vector-icons';
 import { Feather } from '@expo/vector-icons';
-import Home from "./Home-Page.js";
-import Shop from "./Shop-Page.js";
-import Profile from "./Profile-Page.js";
+import HomeStack from "../navigation/HomeStack";
+import ShopStack from "../navigation/ShopStack";
+import ProfileStack from "../navigation/ProfileStack";
 
 const Tab = createBottomTabNavigator();
 
@@ -17,7 +16,7 @@ export default function Tabs() {
             headerShown: false, 
             tabBarShowLabel: false
         }}>
-            <Tab.Screen name="HomeTab" component={Home} 
+            <Tab.Screen name="HomeTab" component={HomeStack}
                 options={{
                 tabBarIcon: ({ focused }) => (
                     <AntDesign 
@@ -28,7 +27,7 @@ export default function Tabs() {
                 )
                 }}
             />
-            <Tab.Screen name="Shop" component={Shop} 
+            <Tab.Screen name="Shop" component={ShopStack}
                 options={{
                 tabBarIcon: ({ focused }) => (
                     <Feather 
@@ -50,7 +49,7 @@ export default function Tabs() {
                 )
                 }}
             /> */}
-            <Tab.Screen name="Profile" component={Profile} 
+            <Tab.Screen name="Profile" component={ProfileStack}
                 options={{
                 tabBarIcon: ({ focused }) => (
                     <MaterialIcons 

--- a/navigation/HomeStack.tsx
+++ b/navigation/HomeStack.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { createStackNavigator } from "@react-navigation/stack";
+import { HomeMain } from "../components/Home-Page";
+import ListingScreen from "../components/Listing-Screen";
+
+const Stack = createStackNavigator();
+
+const HomeStack = () => (
+  <Stack.Navigator>
+    <Stack.Screen
+      name="HomeMain"
+      component={HomeMain}
+      options={{ headerShown: false, headerTitle: "Back" }}
+    />
+    <Stack.Screen
+      name="ListingScreen"
+      component={ListingScreen}
+      options={{ headerTitle: "", headerTintColor: "black" }}
+    />
+  </Stack.Navigator>
+);
+
+export default HomeStack;

--- a/navigation/ProfileStack.tsx
+++ b/navigation/ProfileStack.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { createStackNavigator } from "@react-navigation/stack";
+import { ProfileMain } from "../components/Profile-Page";
+import ListingContainer from "../components/Listing-Screen";
+import CreateListing from "../components/Create-Listing-Screen";
+import EditProfile from "../components/Edit-Profile-Screen";
+import Offers from "../components/Offers-Screen";
+import Checkout from "../components/Checkout-Screen";
+import Archived from "../components/Archived-Offers-Screen";
+
+const Stack = createStackNavigator();
+
+const ProfileStack = () => (
+  <Stack.Navigator>
+    <Stack.Screen
+      name="ProfileMain"
+      component={ProfileMain}
+      options={{ headerShown: false, headerTitle: "Back" }}
+    />
+    <Stack.Screen
+      name="ListingScreen"
+      component={ListingContainer}
+      options={{ headerShown: true, headerTitle: "", headerTintColor: "#0e165c" }}
+    />
+    <Stack.Screen
+      name="CreateListing"
+      component={CreateListing}
+      options={{ headerShown: true, headerTitle: "", headerTintColor: "#0e165c" }}
+    />
+    <Stack.Screen
+      name="EditProfile"
+      component={EditProfile}
+      options={{ headerShown: true, headerTitle: "", headerTintColor: "#0e165c" }}
+    />
+    <Stack.Screen
+      name="Offers"
+      component={Offers}
+      options={{ headerShown: true, headerTitle: "", headerTintColor: "#0e165c" }}
+    />
+    <Stack.Screen
+      name="CheckoutScreen"
+      component={Checkout}
+      options={{ headerShown: true, headerTitle: "", headerTintColor: "#0e165c" }}
+    />
+    <Stack.Screen
+      name="Archived"
+      component={Archived}
+      options={{ headerShown: true, headerTitle: "", headerTintColor: "#0e165c" }}
+    />
+  </Stack.Navigator>
+);
+
+export default ProfileStack;

--- a/navigation/ShopStack.tsx
+++ b/navigation/ShopStack.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { createStackNavigator } from "@react-navigation/stack";
+import { ShopMain } from "../components/Shop-Page";
+import ListingScreen from "../components/Listing-Screen";
+
+const Stack = createStackNavigator();
+
+const ShopStack = () => (
+  <Stack.Navigator>
+    <Stack.Screen
+      name="ShopMain"
+      component={ShopMain}
+      options={{ headerShown: false, headerTitle: "Back" }}
+    />
+    <Stack.Screen
+      name="ListingScreen"
+      component={ListingScreen}
+      options={{ headerTitle: "", headerTintColor: "black" }}
+    />
+  </Stack.Navigator>
+);
+
+export default ShopStack;


### PR DESCRIPTION
## Summary
- move the Home, Shop, and Profile stack definitions into dedicated navigation modules
- export plain screen components from the original files and clean up unused imports
- update the tab navigator to reference the new stack components

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9db996ff8832ba0857c07e22c4e30