### PR TITLE
Lift OffersProvider to root context

### DIFF
--- a/App.js
+++ b/App.js
@@ -11,6 +11,7 @@ import auth from "./firebase/auth";
 import db from './firebase/db'; // Firestore database
 import { doc, getDoc } from "firebase/firestore"; // Firestore methods
 import { ListingsProvider } from "./contexts/listingContext";
+import { OffersProvider } from "./contexts/offersContext";
 import { View, ActivityIndicator, Linking } from "react-native";
 import * as Sentry from '@sentry/react-native';
 import { StripeProvider } from '@stripe/stripe-react-native';
@@ -31,9 +32,11 @@ function AppContainer() {
         urlScheme="campus-closets"
       >
         <AuthProvider>
-          <ListingsProvider>
-            <MainNavigator />
-          </ListingsProvider>
+          <OffersProvider>
+            <ListingsProvider>
+              <MainNavigator />
+            </ListingsProvider>
+          </OffersProvider>
         </AuthProvider>
       </StripeProvider>
     </NavigationContainer>

--- a/components/Archived-Offers-Screen.js
+++ b/components/Archived-Offers-Screen.js
@@ -1,20 +1,12 @@
 import React, { useContext, useState, useEffect } from "react";
 import { Text, View, Image, FlatList, Dimensions, StyleSheet, SafeAreaView } from "react-native";
-import { OffersContext, OffersProvider } from "../contexts/offersContext";
+import { OffersContext } from "../contexts/offersContext";
 import { AuthContext } from "../contexts/authContext";
 import { doc, getDoc } from "@firebase/firestore";
 import db from "../firebase/db";
 import { Image as ExpoImage } from 'expo-image';
 
 const screenWidth = Dimensions.get('window').width;
-
-export default function Archived() {
-    return (
-        <OffersProvider>
-            <ArchivedOffers />
-        </OffersProvider>
-    );
-}
 
 const ArchivedOffers = () => {
     const { inactiveOffers, inactiveSentOffers } = useContext(OffersContext);
@@ -119,6 +111,8 @@ const ArchivedOffers = () => {
         </SafeAreaView>
     );
 };
+
+export default ArchivedOffers;
 
 const styles = StyleSheet.create({
     offerContainer: {

--- a/components/Checkout-Screen.js
+++ b/components/Checkout-Screen.js
@@ -5,18 +5,10 @@ import { AuthContext } from '../contexts/authContext';
 import stripeService from '../util/stripeService';
 import { Image as ExpoImage } from 'expo-image';
 import { SwiperFlatList } from "react-native-swiper-flatlist";
-import { OffersContext, OffersProvider } from '../contexts/offersContext';
+import { OffersContext } from '../contexts/offersContext';
 import { useNavigation } from '@react-navigation/native';
 
-export default function Checkout({ route }) {
-    return (
-        <OffersProvider>
-            <CheckoutScreen route={route} />
-        </OffersProvider>
-    );
-}
-
-const CheckoutScreen = ({ route }) => {
+const Checkout = ({ route }) => {
     const { listing } = route.params;
     const { initPaymentSheet, presentPaymentSheet } = useStripe();
     const { userData, getAccountId } = useContext(AuthContext);
@@ -145,6 +137,8 @@ const CheckoutScreen = ({ route }) => {
         </SafeAreaView>
     );
 };
+
+export default Checkout;
 
 const styles = StyleSheet.create({
     image: {

--- a/components/Listing-Screen.js
+++ b/components/Listing-Screen.js
@@ -14,16 +14,9 @@ import { SwiperFlatList } from "react-native-swiper-flatlist";
 import { AuthContext } from "../contexts/authContext";
 import { Image as ExpoImage } from 'expo-image';
 import { ListingsContext } from "../contexts/listingContext";
-import { OffersProvider, OffersContext } from "../contexts/offersContext";
+import { OffersContext } from "../contexts/offersContext";
 
-export default function ListingContainer({ route }){
-  return (
-    <OffersProvider>
-      <Listing route = {route}/>
-    </OffersProvider>
-  )
-}
-const Listing = ({ route }) => {
+export default function Listing({ route }) {
   const { listing } = route.params;
   const { sendRentalOffer, sendBuyOffer, sentOffers } = useContext(OffersContext);
   const { addLikedListing, removeLikedListing, likedListings, user } = useContext(

--- a/components/Offers-Screen.js
+++ b/components/Offers-Screen.js
@@ -1,8 +1,8 @@
 import React, { useContext, useEffect, useState } from "react";
 import { Text, FlatList, Dimensions, StyleSheet, View, Image, TouchableOpacity, Alert, SafeAreaView } from "react-native";
-import { OffersProvider, OffersContext } from "../contexts/offersContext";
+import { OffersContext } from "../contexts/offersContext";
 import { Entypo } from '@expo/vector-icons';
-import { ListingsContext, ListingsProvider } from '../contexts/listingContext';
+import { ListingsContext } from '../contexts/listingContext';
 import { ScrollView } from "react-native-gesture-handler";
 import { useNavigation } from "@react-navigation/native";
 import { SwiperFlatList } from "react-native-swiper-flatlist";
@@ -12,16 +12,6 @@ import { Image as ExpoImage } from 'expo-image';
 import * as Sentry from '@sentry/react-native';
 import stripeService from "../util/stripeService";
 import { AuthContext } from "../contexts/authContext";
-
-export default function OffersContainer() {
-    return (
-        <ListingsProvider>
-            <OffersProvider>
-                <Offers />
-            </OffersProvider>
-        </ListingsProvider>
-    );
-}
 
 const { width } = Dimensions.get('window');
 
@@ -230,8 +220,10 @@ const Offers = () => {
                 <Text style={styles.navigationButtonText}>View Past Transactions</Text>
             </TouchableOpacity>
         </SafeAreaView>
-    )
+    );
 };
+
+export default Offers;
 
 const styles = StyleSheet.create({
     loadingContainer: {

--- a/contexts/offersContext.js
+++ b/contexts/offersContext.js
@@ -1,7 +1,6 @@
 import { createContext, useContext, useState, useEffect } from "react";
 import { addDoc, getDoc, doc, updateDoc, collection, deleteDoc, getDocs, onSnapshot, query, where, arrayUnion, arrayRemove } from "firebase/firestore";
 import { AuthContext } from "./authContext";
-import { ListingsContext } from "./listingContext"; 
 import db from "../firebase/db";
 import * as Sentry from '@sentry/react-native';
 
@@ -9,7 +8,6 @@ export const OffersContext = createContext();
 
 export const OffersProvider = ({ children }) => {
     const { user } = useContext(AuthContext);
-    const { removeListing } = useContext(ListingsContext); 
     const [sentOffers, setSentOffers] = useState([]);
     const [activeOffers, setActiveOffers] = useState([]);
     const [inactiveOffers, setInactiveOffers] = useState([]);


### PR DESCRIPTION
## Summary
- wrap the navigation hierarchy with the global OffersProvider so offer data is shared application-wide
- remove per-screen OffersProvider wrappers now that the context is provided at the app root
- clean up the offers context by dropping an unused dependency on ListingsContext

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9db9e2bc0832b9efffea072721c34